### PR TITLE
Add mica-sidecar init container

### DIFF
--- a/concord/files/server/server.conf
+++ b/concord/files/server/server.conf
@@ -129,11 +129,6 @@ concord-server {
   {{ if .Values.mica.enabled }}
   mica {
       oidc {
-        clientId = "{{ .Values.oidc.clientId }}"
-        clientSecret = "{{ .Values.oidc.secret }}"
-        authorizationEndpoint = "{{ .Values.oidc.authServer }}/oauth2/v1/authorize"
-        tokenEndpoint = "{{ .Values.oidc.authServer }}/oauth2/v1/token"
-        userinfoEndpoint = "{{ .Values.oidc.authServer }}/oauth2/v1/userinfo"
         logoutEndpoint = "{{ .Values.oidc.authServer }}/login/signout"
       }
   }

--- a/concord/templates/server/deployment.yaml
+++ b/concord/templates/server/deployment.yaml
@@ -22,14 +22,23 @@ spec:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ .Values.serviceAccount.name }}            
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- include "imagePullSecretName" . | nindent 6 }}
       # https://medium.com/@xcoulon/initializing-containers-in-order-with-kubernetes-18173b9cc222
-      {{- if eq .Values.database.type "internal" }}
       initContainers:
-      - name: postgres-ready
-        image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
-        command: ['sh', '-c', 'until pg_isready -h postgresql -p 5432; do echo waiting for database; sleep 2; done; sleep 10;']
+      {{- if eq .Values.database.type "internal" }}
+        - name: postgres-ready
+          image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
+          command: [ 'sh', '-c', 'until pg_isready -h postgresql -p 5432; do echo waiting for database; sleep 2; done; sleep 10;' ]
+      {{- end }}
+      {{- if .Values.mica.enabled }}
+        - name: mica-sidecar
+          image: {{ .Values.mica.sidecarImage }}
+          command: [ 'sh', '-c', 'ls /mica/ && cp /dist/* /mica/' ]
+          imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+          volumeMounts:
+            - name: mica-jars
+              mountPath: /mica/
       {{- end }}
       containers:
         - name: concord-server
@@ -49,6 +58,10 @@ spec:
             - name: cfg
               mountPath: "/opt/concord/console/cfg.js"
               subPath: cfg.js
+            {{- if .Values.mica.enabled }}
+            - name: mica-jars
+              mountPath: /mica/
+            {{- end }}
           ports:
             - containerPort: 8001
           env:
@@ -56,6 +69,10 @@ spec:
               value: /opt/concord/conf/server.conf
             - name: CONCORD_MAVEN_CFG
               value: "/opt/concord/conf/mvn.json"
+            {{- if .Values.mica.enabled }}
+            - name: EXTRA_CLASSPATH
+              value: "/mica/*"
+            {{- end }}
             {{- range $key, $val := .Values.server.env }}
             - name: {{ $key }}
               value: {{ $val | quote }}
@@ -68,6 +85,10 @@ spec:
         - name: cfg
           configMap:
             name: server-cfg
+        {{- if .Values.mica.enabled }}
+        - name: mica-jars
+          emptyDir: { }
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/concord/values.yaml
+++ b/concord/values.yaml
@@ -189,6 +189,7 @@ serviceAccount:
 mica:
   # should only be enabled when using a concord-server Docker image that includes the Mica plugin
   enabled: false
+  sidecarImage: "concordworkflow/mica-sidecar:initial"
 
 # --------------------------------------------------------------------------------------------------------------------
 # Others


### PR DESCRIPTION
Instead of bundling Mica with a concord-server image we're going to use an init container that copies Mica JARs into the shared directory.

Requires https://github.com/concord-workflow/mica/commit/15e953d085ad4bd71f9b7fbcc7e52d834108418a
and https://github.com/walmartlabs/concord/pull/836/commits/7bfd18962e68d719d85b4e024079bf34009d813a