### PR TITLE
add readinessProbe to concord-server

### DIFF
--- a/concord/files/server/server.conf
+++ b/concord/files/server/server.conf
@@ -32,7 +32,7 @@ concord-server {
   {{ end }}
 
   server {
-    secureCookies = true # only for HTTPS
+    secureCookies = {{ .Values.expose.tls.enabled }} # only for HTTPS
   }
 
   process {

--- a/concord/templates/server/deployment.yaml
+++ b/concord/templates/server/deployment.yaml
@@ -64,6 +64,13 @@ spec:
             {{- end }}
           ports:
             - containerPort: 8001
+          readinessProbe:
+            httpGet:
+              port: 8001
+              path: /api/v1/server/ping
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 5
           env:
             - name: CONCORD_CFG_FILE
               value: /opt/concord/conf/server.conf


### PR DESCRIPTION
also: allow http cookies when running w/o tls

Fixes https://github.com/concord-workflow/concord-charts/issues/25