### PR TITLE
concord-server: increase sessionTimeout by default

### DIFF
--- a/concord/files/server/server.conf
+++ b/concord/files/server/server.conf
@@ -33,6 +33,7 @@ concord-server {
 
   server {
     secureCookies = {{ .Values.expose.tls.enabled }} # only for HTTPS
+    sessionTimeout = "{{ .Values.server.sessionTimeout }}"
   }
 
   process {

--- a/concord/values.yaml
+++ b/concord/values.yaml
@@ -91,6 +91,7 @@ server:
   maxLogAge: "7 days"
   maxStateAge: "7 days"
   maxStalledAge: "1 minute"
+  sessionTimeout: "3 hours"
   
   # Map of extra environment variables to pass to server
   env: {}


### PR DESCRIPTION
I've a suspicion we need Jetty session timeout > OIDC session timeout for pax4j-oidc to work correctly due to the way they handle OIDC's `state`.