### PR TITLE
Add ServiceMonitor for concord-server

### DIFF
--- a/concord/templates/server/service-monitor.yaml
+++ b/concord/templates/server/service-monitor.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.server.serviceMonitor.enabled -}}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: concord-server
+  labels:
+    app: concord-server
+{{- with .Values.server.serviceMonitor.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.server.serviceMonitor.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: concord-server
+  endpoints:
+    - port: http
+{{- end }}

--- a/concord/values.yaml
+++ b/concord/values.yaml
@@ -92,6 +92,10 @@ server:
   maxStateAge: "7 days"
   maxStalledAge: "1 minute"
   sessionTimeout: "3 hours"
+  serviceMonitor:
+    enabled: false # enable to create a monitoring.coreos.com/v1 ServiceMonitor for the server with the given labels
+    labels: {}
+    annotations: {}
   
   # Map of extra environment variables to pass to server
   env: {}


### PR DESCRIPTION
Tested using `kind` by following https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md

![image](https://github.com/concord-workflow/concord-charts/assets/826959/348f7044-cbe3-45f7-bfc1-9e0e22c52245)


