### PR TITLE
concord-server: add extraEnv, extraSecrets

### DIFF
--- a/concord/templates/security/server-credentials.yaml
+++ b/concord/templates/security/server-credentials.yaml
@@ -22,6 +22,9 @@
   {{- if .Values.git }}{{- if .Values.git.oauth }}
   GIT_OAUTH: {{ .Values.git.oauth | quote }}
   {{- end }}{{- end }}
+  {{- range $key, $val := .Values.server.extraSecrets }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
 {{ end }}
 ---
 apiVersion: v1

--- a/concord/templates/server/deployment.yaml
+++ b/concord/templates/server/deployment.yaml
@@ -141,7 +141,7 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
-            {{- if .Values.server.env }}
+            {{- if .Values.server.extraEnv }}
             {{- toYaml .Values.server.extraEnv | nindent 12 }}
             {{- end}}
           {{- if .Values.serverResources }}

--- a/concord/templates/server/deployment.yaml
+++ b/concord/templates/server/deployment.yaml
@@ -141,6 +141,9 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
+            {{- if .Values.server.env }}
+            {{- toYaml .Values.server.extraEnv | nindent 12 }}
+            {{- end}}
           {{- if .Values.serverResources }}
           resources:
             {{- toYaml .Values.serverResources | nindent 12 }}

--- a/concord/values.yaml
+++ b/concord/values.yaml
@@ -100,7 +100,12 @@ server:
     annotations: {}
 
   # Map of extra environment variables to pass to server
+  # (deprecated in favor of server.extraEnv)
   env: {}
+  # LIST of extra environment variables to pass to server in the regular template.spec.containers[].env format
+  extraEnv: []
+  # MAP of extra secrets
+  extraSecrets: {}
 
 agent:
   readTimeout: "10 seconds"


### PR DESCRIPTION
Add `server.extraEnv` that allows passing secretRefs and such instead of plain values.
Add `server.extraSecrets` to insert additional secret KVs into concord-server-credentials.
Useful for sidecars.